### PR TITLE
Dividers nella BoringSection

### DIFF
--- a/lib/boring_app/boring_drawer_entry.dart
+++ b/lib/boring_app/boring_drawer_entry.dart
@@ -40,6 +40,9 @@ class BoringDrawerEntry extends StatelessWidget {
     }
     return Column(
       children: [
+        SizedBox(
+          height: tileStyle.tileSpacing / 2,
+        ),
         InkWell(
             onTap: () => GoRouter.of(context).go(path),
             onHover: (val) {
@@ -95,7 +98,7 @@ class BoringDrawerEntry extends StatelessWidget {
               },
             )),
         SizedBox(
-          height: tileStyle.tileSpacing,
+          height: tileStyle.tileSpacing / 2,
         )
       ],
     );

--- a/lib/boring_app/boring_page/boring_page_base.dart
+++ b/lib/boring_app/boring_page/boring_page_base.dart
@@ -7,12 +7,11 @@ import 'package:go_router/go_router.dart';
 import '../style/boring_drawer_tile_style.dart';
 
 abstract class BoringPageBase {
-
   Widget? buildDrawerEntry(
       BuildContext context, BoringDrawerTileStyle tileStyle,
       [String fullPathPrefix]);
 
-  bool get isHidden;
+  bool get isHiddenFromDrawer;
 
   List<GoRoute> getRoutes(
       {bool addPrefix = false,

--- a/lib/boring_app/boring_section.dart
+++ b/lib/boring_app/boring_section.dart
@@ -75,7 +75,6 @@ class BoringSection {
         child: child,
       );
 
-
   Drawer drawer(BuildContext context) => Drawer(
         shape: RoundedRectangleBorder(borderRadius: drawerStyle.drawerRadius),
         elevation: drawerStyle.drawerElevation,
@@ -119,9 +118,7 @@ class BoringSection {
               child: LayoutBuilder(builder: (context, constraints) {
                 return Scaffold(
                   key: _drawerKey,
-                  drawer: constraints.maxWidth > 750
-                      ? null
-                      : drawer(context, drawerShow: true),
+                  drawer: constraints.maxWidth > 750 ? null : drawer(context),
                   body: constraints.maxWidth > 750
                       ? Padding(
                           padding: drawerStyle.drawerForeignPadding,

--- a/lib/boring_app/boring_section.dart
+++ b/lib/boring_app/boring_section.dart
@@ -14,6 +14,8 @@ class BoringSection {
   final String? defaultPath;
   final BoringDrawerStyle drawerStyle;
   final BoringDrawerTileStyle drawerTileStyle;
+  final List<int> dividersAtIndexes;
+  final Widget Function(BuildContext context)? dividerBuilder;
   final FutureOr<String?> Function(BuildContext context, GoRouterState state)?
       redirect;
 
@@ -28,6 +30,8 @@ class BoringSection {
       this.drawerFooterBuilder,
       this.defaultPath,
       this.redirect,
+      this.dividerBuilder,
+      this.dividersAtIndexes = const [],
       this.drawerStyle = const BoringDrawerStyle(),
       this.drawerTileStyle = const BoringDrawerTileStyle()}) {
     _assertions();
@@ -75,28 +79,38 @@ class BoringSection {
         child: child,
       );
 
-  Drawer drawer(BuildContext context) => Drawer(
-        shape: RoundedRectangleBorder(borderRadius: drawerStyle.drawerRadius),
-        elevation: drawerStyle.drawerElevation,
-        child: drawerWrap(Column(
-          children: [
-            if (drawerHeaderBuilder != null) drawerHeaderBuilder!(context),
-            Expanded(
-              child: SingleChildScrollView(
-                padding: drawerStyle.drawerContentPadding,
-                child: Column(
-                  children: children
-                      .map((e) => e.buildDrawerEntry(
-                          context, drawerTileStyle, hasPath ? path! : ""))
-                      .whereType<Widget>()
-                      .toList(),
-                ),
+  Drawer drawer(BuildContext context) {
+    List<Widget> _children = children
+        .map((e) =>
+            e.buildDrawerEntry(context, drawerTileStyle, hasPath ? path! : ""))
+        .whereType<Widget>()
+        .toList();
+    int itemsAdded = 0;
+    dividersAtIndexes.forEach((e) {
+      _children.insert(
+          e + itemsAdded, dividerBuilder?.call(context) ?? const Divider());
+      itemsAdded++;
+    });
+
+    return Drawer(
+      shape: RoundedRectangleBorder(borderRadius: drawerStyle.drawerRadius),
+      elevation: drawerStyle.drawerElevation,
+      child: drawerWrap(Column(
+        children: [
+          if (drawerHeaderBuilder != null) drawerHeaderBuilder!(context),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: drawerStyle.drawerContentPadding,
+              child: Column(
+                children: _children,
               ),
             ),
-            if (drawerFooterBuilder != null) drawerFooterBuilder!(context),
-          ],
-        )),
-      );
+          ),
+          if (drawerFooterBuilder != null) drawerFooterBuilder!(context),
+        ],
+      )),
+    );
+  }
 
   List<RouteBase> _getChildrenRoutes(bool hiddenFromDrawer) => children
       .where((element) => element.isHiddenFromDrawer == hiddenFromDrawer)


### PR DESCRIPTION
<img width="586" alt="dividers" src="https://user-images.githubusercontent.com/45425606/219849141-ca7626eb-3f69-4258-88da-19d063a4e0aa.png">

Ho deciso di implementare i Dividers in questo modo.

- [dividersAtIndexes] è una lista che prende in input degli interi, ovvero le posizioni in cui vogliamo inserire i nostri dividers. Ovviamente possiamo inserirne anche uno solo, la lista avrà 1 solo elemento.
- [dividerBuilder] è una funzione che permette all'utente di buildare il proprio divider. E' facoltativa e nel caso non fosse specificata, la libreria genera in automatico un Divider classico. 